### PR TITLE
Fix EfiStatus typo

### DIFF
--- a/bootloader/src/uefi.rs
+++ b/bootloader/src/uefi.rs
@@ -14,7 +14,7 @@ pub enum EfiStatus {
     Success,
     LoadError,
     InvalidParameter,
-    Unsupprted,
+    Unsupported,
     BadBufferSize,
     BufferTooSmall,
     NotReady,


### PR DESCRIPTION
## Summary
- fix typo in `EfiStatus` enum

## Testing
- `cargo build` *(fails: target triple in channel name `nightly-2022-02-23-x86_64-unknown-linux-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_684049268b48832aa403c2145589eb29